### PR TITLE
ci: add Linux ARM64 prebuilt release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             archive: tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            archive: tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
             archive: tar.gz
@@ -38,7 +41,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Linux ARM64 cross toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (Unix)

--- a/docs/CROSS_PLATFORM_INSTALL.md
+++ b/docs/CROSS_PLATFORM_INSTALL.md
@@ -12,6 +12,17 @@ curl -fsSL https://raw.githubusercontent.com/skbotoc1-web/openclaw-rust-toolkit/
 irm https://raw.githubusercontent.com/skbotoc1-web/openclaw-rust-toolkit/main/scripts/install.ps1 | iex
 ```
 
+## Release assets
+
+Releases include prebuilt binaries for:
+- `octk-x86_64-unknown-linux-gnu.tar.gz`
+- `octk-aarch64-unknown-linux-gnu.tar.gz`
+- `octk-x86_64-apple-darwin.tar.gz`
+- `octk-aarch64-apple-darwin.tar.gz`
+- `octk-x86_64-pc-windows-msvc.zip`
+
+Each artifact has a matching checksum file: `SHA256SUMS-<target>.txt`.
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
## Summary
- add `aarch64-unknown-linux-gnu` to the release matrix on `ubuntu-latest`
- install `gcc-aarch64-linux-gnu` and configure linker for ARM64 cross-builds
- keep checksum generation/upload path unchanged so ARM64 assets get matching `SHA256SUMS` files
- document ARM64 release artifact in cross-platform install docs

## Validation
- `python3` YAML parse check for `.github/workflows/release.yml` passed
- `git diff --check` passed
- full Rust test/build commands are blocked locally because `cargo` is not installed in this environment

Fixes #3
