### PR TITLE
ci: add release artifact signing and provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -66,6 +68,38 @@ jobs:
           $hash = (Get-FileHash "octk-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
           "$hash  octk-${{ matrix.target }}.zip" | Out-File -FilePath "SHA256SUMS-${{ matrix.target }}.txt" -Encoding ascii
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign release artifacts (keyless)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ASSET="octk-${{ matrix.target }}.${{ matrix.archive }}"
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            ASSET="octk-${{ matrix.target }}.zip"
+          fi
+
+          cosign sign-blob --yes "$ASSET" \
+            --output-signature "$ASSET.sig" \
+            --output-certificate "$ASSET.pem"
+
+          SUMS="SHA256SUMS-${{ matrix.target }}.txt"
+          cosign sign-blob --yes "$SUMS" \
+            --output-signature "$SUMS.sig" \
+            --output-certificate "$SUMS.pem"
+
+      - name: Generate GitHub artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            octk-${{ matrix.target }}.tar.gz
+            octk-${{ matrix.target }}.zip
+            SHA256SUMS-${{ matrix.target }}.txt
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
@@ -74,5 +108,11 @@ jobs:
             octk-${{ matrix.target }}.tar.gz
             octk-${{ matrix.target }}.zip
             SHA256SUMS-${{ matrix.target }}.txt
+            octk-${{ matrix.target }}.tar.gz.sig
+            octk-${{ matrix.target }}.tar.gz.pem
+            octk-${{ matrix.target }}.zip.sig
+            octk-${{ matrix.target }}.zip.pem
+            SHA256SUMS-${{ matrix.target }}.txt.sig
+            SHA256SUMS-${{ matrix.target }}.txt.pem
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,25 @@ scripts/last-deploy-status.sh --require-success --min-assets 3 --max-age-hours 7
 ```
 
 ### Release integrity
-Each release publishes per-target checksum files (`SHA256SUMS-<target>.txt`) alongside binaries.
+Each release publishes per-target checksum files (`SHA256SUMS-<target>.txt`) alongside binaries, plus keyless Sigstore signatures/certificates (`.sig` + `.pem`) and GitHub provenance attestations.
+
+Verification (example for Linux x86_64):
+```bash
+# 1) checksum validation
+sha256sum -c SHA256SUMS-x86_64-unknown-linux-gnu.txt
+
+# 2) keyless signature verification
+cosign verify-blob \
+  --certificate octk-x86_64-unknown-linux-gnu.tar.gz.pem \
+  --signature octk-x86_64-unknown-linux-gnu.tar.gz.sig \
+  --certificate-identity-regexp "https://github.com/skbotoc1-web/openclaw-rust-toolkit/.github/workflows/release.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  octk-x86_64-unknown-linux-gnu.tar.gz
+
+# 3) provenance attestation verification
+gh attestation verify octk-x86_64-unknown-linux-gnu.tar.gz \
+  --repo skbotoc1-web/openclaw-rust-toolkit
+```
 
 ### Wrapper controls
 ```bash


### PR DESCRIPTION
## Summary
- extend release workflow permissions for OIDC keyless signing and attestations
- install Cosign and sign each release binary/checksum artifact with keyless Sigstore certs
- generate GitHub build provenance attestations for release subjects
- upload `.sig` and `.pem` files with release assets
- add verification commands (checksum, cosign verify-blob, gh attestation verify) to README

## Validation
- `python3` YAML parse check for `.github/workflows/release.yml` passed
- `git diff --check` passed
- full Rust test/build commands are blocked locally because `cargo` is not installed in this environment

Fixes #4
