### PR TITLE
feat: PR1 local-first router decision engine + policy + QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Optional Rust layer for OpenClaw command output: **activate only when useful**, 
 ## Quick value (what you get in practice)
 - Real-world reduction: **~70–85% fewer prompt tokens** on noisy CLI output
 - Deterministic behavior (rules), not black-box summarization
+- Local-first routing foundation: route simple tasks local, escalate to cloud only when needed
 - Works as an optional external layer (upgrade-safe)
 
 ## 60-second verification
@@ -99,6 +100,17 @@ cosign verify-blob \
 # 3) provenance attestation verification
 gh attestation verify octk-x86_64-unknown-linux-gnu.tar.gz \
   --repo skbotoc1-web/openclaw-rust-toolkit
+```
+
+### Router dry-run (policy decision log)
+```bash
+# decision simulation with policy file
+./target/release/octk \
+  --route-task classify \
+  --route-confidence 0.82 \
+  --route-schema-valid true \
+  --route-policy ./policies/router.toml \
+  --emit-route-log
 ```
 
 ### Wrapper controls
@@ -196,6 +208,9 @@ See: `docs/OPENCLAW_INTEGRATION.md`
 - `docs/MOAT_POSITIONING.md`
 - `docs/ENTERPRISE_READINESS.md`
 - `docs/PRODUCT_GUARDRAILS.md`
+- `docs/LOCAL_FIRST_ROUTING_ARCHITECTURE.md`
+- `docs/EXECUTION_PLAN_14D_LOCAL_FIRST.md`
+- `docs/QA_VALIDATION_2026-03-23_LOCAL_FIRST_PR1.md`
 - `SECURITY.md`, `scripts/secret-check.sh`
 
 If you run this in production, open an issue with:

--- a/docs/EXECUTION_PLAN_14D_LOCAL_FIRST.md
+++ b/docs/EXECUTION_PLAN_14D_LOCAL_FIRST.md
@@ -1,0 +1,42 @@
+# 14-Tage Ausführungsplan (Local-First)
+
+## Woche 1
+
+### Tag 1-2
+PR-1: Router-Schema + deterministische Decision Engine
+- Deliverables: `policies/router.toml`, Decision-Log, Unit-Tests
+
+### Tag 3-4
+PR-2: Local Embeddings Lane
+- Deliverables: embedding runner interface, local-only baseline benchmark
+
+### Tag 5-7
+PR-3: Small-Model Lane (classify/extract)
+- Deliverables: confidence scoring, schema validator, escalation trigger
+
+## Woche 2
+
+### Tag 8-9
+PR-4: Cloud Escalation + Budget Gates
+- Deliverables: soft/hard limit handling, retry budget, reason codes
+
+### Tag 10-11
+PR-5: Telemetry + KPI Daily Rollup
+- Deliverables: jsonl events, KPI report generator, baseline dashboard md
+
+### Tag 12-13
+PR-6: Marketing Proof Pack
+- Deliverables: 3 benchmark kits, before/after cost sheet, quality report
+
+### Tag 14
+Release Candidate
+- `v0.3.0-rc1`
+- full QA loop + release checklist + go/no-go
+
+---
+
+## Go/No-Go Kriterien
+- Cloud-Calls für Embeddings in Baseline: **0**
+- Lokale Trefferquote für `classify/extract`: **>=70%**
+- Kostenreduktion ggü. cloud-only baseline: **>=40%**
+- Kein kritischer Debug-Signalverlust

--- a/docs/LAUNCH_POST_DE.md
+++ b/docs/LAUNCH_POST_DE.md
@@ -12,6 +12,7 @@ Das erhöht Kosten, Latenz und drückt auf das Context Window.
 - deterministisches Condensing (kein Black-Box-Summarizing)
 - Profile (`safe`, `balanced`, `aggressive`)
 - klare Marker + messbare Token-Einsparung
+- Local-First Router Dry-Run (policy-basierte Routenentscheidung)
 - fail-open Design (kein OpenClaw-Core-Patching)
 
 ## Reale Zahlen
@@ -30,5 +31,5 @@ https://github.com/skbotoc1-web/openclaw-rust-toolkit
 
 ## Feedback gesucht
 1. eure realen Savings
-2. edge cases bei Debug-Qualität
-3. Priorität Linux ARM64 Binaries
+2. sinnvolle Local-First Schwellen (Confidence/Budget-Gates)
+3. edge cases bei Debug-Qualität

--- a/docs/LAUNCH_POST_EN.md
+++ b/docs/LAUNCH_POST_EN.md
@@ -12,6 +12,7 @@ That increases cost, latency, and context pressure.
 - deterministic condensing (not black-box summarization)
 - profile presets (`safe`, `balanced`, `aggressive`)
 - explicit usage markers + measurable token savings
+- local-first router dry-run (policy-based route decisions)
 - fail-open design (no OpenClaw core patching)
 
 ## Real numbers
@@ -31,5 +32,5 @@ https://github.com/skbotoc1-web/openclaw-rust-toolkit
 ## Ask
 Would love feedback on:
 1. your real-world token savings
-2. missed-debug edge cases
-3. Linux ARM64 binary support priorities
+2. local-first routing thresholds (confidence/budget gates)
+3. missed-debug edge cases

--- a/docs/LOCAL_FIRST_ROUTING_ARCHITECTURE.md
+++ b/docs/LOCAL_FIRST_ROUTING_ARCHITECTURE.md
@@ -1,0 +1,123 @@
+# Local-First Routing Architecture (Cost + Reliability)
+
+## Ziel
+Cloud-API nur nutzen, wenn lokal nicht ausreicht.
+
+## 3-Block-Architektur
+
+### 1) Request Router (Policy Engine)
+Entscheidet pro Request:
+- `local_only`
+- `local_then_cloud`
+- `cloud_only`
+
+Input-Signale:
+- Task-Klasse (`embed`, `classify`, `extract`, `summarize`, `reasoning`)
+- Risiko/Qualität (confidence, schema-validierung)
+- Budget (daily/monthly limits)
+- Latenz-SLA
+- Sicherheitskontext (PII/sensitive)
+
+### 2) Local Inference Layer
+- **Embeddings lokal** (RAG-Workloads)
+- **Small Models lokal** für einfache Aufgaben
+- Ergebnis mit Confidence + Quality Flags
+
+### 3) Cloud Escalation Layer
+- Eskalation nur bei Gates:
+  - confidence < threshold
+  - validation failed
+  - hard task class
+  - explicit cloud-required policy
+
+---
+
+## Default-Policy (v1)
+1. `embed` => `local_only`
+2. `classify|extract` => `local_then_cloud`
+3. `summarize` => `local_then_cloud` (bei quality fail eskalieren)
+4. `reasoning|high-risk` => `cloud_only`
+
+Hard Stops:
+- Budget hard limit erreicht => kein `cloud_only`, nur degradierter lokaler Modus
+- Rate limit aktiv => Backoff + Queue + Retry-Budget
+
+---
+
+## KPI-Framework (No metric, no merge)
+Pflichtmetriken pro PR:
+- `local_hit_rate`
+- `cloud_escalation_rate`
+- `cache_hit_rate`
+- `estimated_tokens_saved`
+- `cost_per_1k_requests`
+- `p95_latency`
+- `quality_fail_rate`
+- `missed_signal_incidents`
+
+---
+
+## PR-Slices (implementierbar)
+
+### PR-1: Policy-Schema + Router Skeleton
+- config: `policies/router.toml`
+- task classification + route decision (ohne model execution)
+- structured decision log
+
+**Akzeptanzkriterien**
+- deterministische Entscheidungen für identische Inputs
+- unit tests für alle route outcomes
+
+### PR-2: Local Embeddings Lane
+- lokaler embedding-runner + health check
+- local index write path (RAG)
+- fallback reason codes
+
+**Akzeptanzkriterien**
+- `embed` requests laufen ohne Cloud
+- benchmark report: cloud calls for embeddings = 0 in baseline suite
+
+### PR-3: Small-Model Local Lane
+- lokale inferenz für `classify/extract`
+- confidence score + schema validation
+
+**Akzeptanzkriterien**
+- valid responses bei baseline tasks
+- automatische escalation bei low confidence
+
+### PR-4: Cloud Escalation + Budget Gates
+- escalation adapter
+- daily/monthly budget watchdog
+- hard/soft limits + clear failure modes
+
+**Akzeptanzkriterien**
+- soft limit => warning event
+- hard limit => cloud blocked + degradierter lokaler fallback
+
+### PR-5: End-to-End Telemetry + Daily Report
+- metrics emission (jsonl)
+- daily KPI rollup + report artifact
+
+**Akzeptanzkriterien**
+- alle Pflichtmetriken vorhanden
+- before/after report für token+cost
+
+### PR-6: Marketing Proof Pack
+- 3 reproduzierbare benchmark cases
+- cost before/after sheet
+- quality gate report (no missed critical signal)
+
+**Akzeptanzkriterien**
+- publish-ready assets in `docs/` + reusable snippets
+
+---
+
+## Risiko-Management
+- Fail-open nur für nichtkritische Workflows
+- High-risk flows fail-closed mit klaren Fehlercodes
+- Rollback: Router kann global auf `cloud_only` oder `local_only` gestellt werden
+
+---
+
+## Positioning-Satz (extern)
+"Cloud only when needed: deterministic local-first routing with measurable savings and safe escalation."

--- a/docs/MOAT_POSITIONING.md
+++ b/docs/MOAT_POSITIONING.md
@@ -5,6 +5,7 @@ Token hygiene infrastructure for agentic CLI workflows.
 
 ## Core thesis
 The moat is **operational reliability + measurable impact**, not just compression.
+Now extended to **local-first routing discipline** (cloud only when needed).
 
 ## Why this wins
 1. **Ops-native integration**

--- a/docs/QA_VALIDATION_2026-03-23_LOCAL_FIRST_PR1.md
+++ b/docs/QA_VALIDATION_2026-03-23_LOCAL_FIRST_PR1.md
@@ -1,0 +1,60 @@
+# QA + Validation Report — Local-First Router PR1 (2026-03-23)
+
+## Scope
+- Router policy schema + deterministic decision engine
+- CLI router dry-run mode + structured decision log
+- Policy file baseline (`policies/router.toml`)
+
+## Test/Validation Matrix
+
+### A) Testen
+Commands:
+```bash
+cargo test -q
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Result:
+- `cargo test`: **22/22 passed**
+- `cargo fmt --check`: **pass**
+- `cargo clippy -D warnings`: **pass**
+
+### B) Reparieren
+- Keine Defekte nach Testlauf.
+- Nur rustfmt-Layout-Anpassungen wurden automatisch angewendet.
+
+### C) Validieren (behavioral)
+Dry-run checks:
+```bash
+cargo run --quiet -- --route-task embed --route-policy ./policies/router.toml
+cargo run --quiet -- --route-task reasoning --route-policy ./policies/router.toml
+cargo run --quiet -- --route-task classify --route-confidence 0.90 --route-schema-valid true --route-policy ./policies/router.toml
+cargo run --quiet -- --route-task classify --route-confidence 0.20 --route-schema-valid true --route-policy ./policies/router.toml
+cargo run --quiet -- --route-task high_risk --route-budget-hard-limit --route-policy ./policies/router.toml
+```
+
+Observed routes:
+- `embed` -> `local_only`
+- `reasoning` -> `cloud_only`
+- `classify(0.90)` -> `local_only`
+- `classify(0.20)` -> `local_then_cloud`
+- `high_risk + hard_budget` -> `local_only` (degraded local)
+
+### D) Dokumentieren
+Neu/aktualisiert:
+- `docs/LOCAL_FIRST_ROUTING_ARCHITECTURE.md`
+- `docs/EXECUTION_PLAN_14D_LOCAL_FIRST.md`
+- `README.md` (router dry-run + local-first value statement)
+
+---
+
+## No-Metric-No-Merge Block
+- Unit tests: **22 passed / 0 failed**
+- Router outcomes (expected baseline cases): **5/5 expected**
+- Compile/lint quality gates: **green**
+- Runtime overhead router dry-run: negligible (single local decision path)
+
+## Release risk assessment
+- Risk level: **low** (additive dry-run feature, no breaking change to existing condense flow)
+- Rollback path: keep using existing `octk` condense mode (router mode optional)

--- a/policies/router.toml
+++ b/policies/router.toml
@@ -1,0 +1,13 @@
+policy_version = "router-v1"
+
+[thresholds]
+min_local_confidence = 0.78
+
+[defaults]
+embed = "local_only"
+classify = "local_then_cloud"
+extract = "local_then_cloud"
+summarize = "local_then_cloud"
+reasoning = "cloud_only"
+high_risk = "cloud_only"
+unknown = "local_then_cloud"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
+mod router;
+
 #[derive(Parser, Debug)]
 #[command(name = "octk", version, about = "OpenClaw Rust Toolkit")]
 struct Cli {
@@ -28,6 +30,30 @@ struct Cli {
 
     #[arg(long, default_value_t = false)]
     emit_flag: bool,
+
+    #[arg(long, value_enum)]
+    route_task: Option<router::TaskClass>,
+
+    #[arg(long)]
+    route_policy: Option<PathBuf>,
+
+    #[arg(long)]
+    route_confidence: Option<f64>,
+
+    #[arg(long)]
+    route_schema_valid: Option<bool>,
+
+    #[arg(long, default_value_t = false)]
+    route_budget_soft_limit: bool,
+
+    #[arg(long, default_value_t = false)]
+    route_budget_hard_limit: bool,
+
+    #[arg(long, default_value_t = false)]
+    route_cloud_required: bool,
+
+    #[arg(long, default_value_t = false)]
+    emit_route_log: bool,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -411,6 +437,30 @@ fn process_input(
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if let Some(task_class) = cli.route_task.clone() {
+        let policy = router::load_policy(cli.route_policy.as_deref())?;
+        let input = router::RouteInput {
+            task_class,
+            confidence: cli.route_confidence,
+            schema_valid: cli.route_schema_valid,
+            budget_soft_limit_reached: cli.route_budget_soft_limit,
+            budget_hard_limit_reached: cli.route_budget_hard_limit,
+            cloud_required: cli.route_cloud_required,
+        };
+        let decision = router::decide_route(&input, &policy);
+
+        let route_json = serde_json::to_string_pretty(&decision)?;
+        println!("{}", route_json);
+
+        if cli.emit_route_log {
+            let log_line = router::decision_log_json(&decision)?;
+            eprintln!("[ROUTER_DECISION] {}", log_line);
+        }
+
+        return Ok(());
+    }
+
     let rules = load_rules(cli.rules)?;
 
     let mut input = String::new();

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,420 @@
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Clone, Debug, ValueEnum, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[value(rename_all = "snake_case")]
+pub enum TaskClass {
+    Embed,
+    Classify,
+    Extract,
+    Summarize,
+    Reasoning,
+    HighRisk,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Route {
+    LocalOnly,
+    LocalThenCloud,
+    CloudOnly,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RouterPolicy {
+    pub policy_version: Option<String>,
+    pub thresholds: Option<RouterThresholds>,
+    pub defaults: Option<RouterDefaults>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RouterThresholds {
+    pub min_local_confidence: Option<f64>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RouterDefaults {
+    pub embed: Option<Route>,
+    pub classify: Option<Route>,
+    pub extract: Option<Route>,
+    pub summarize: Option<Route>,
+    pub reasoning: Option<Route>,
+    pub high_risk: Option<Route>,
+    pub unknown: Option<Route>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EffectiveRouterPolicy {
+    pub policy_version: String,
+    pub min_local_confidence: f64,
+    pub defaults: EffectiveRouterDefaults,
+}
+
+#[derive(Clone, Debug)]
+pub struct EffectiveRouterDefaults {
+    pub embed: Route,
+    pub classify: Route,
+    pub extract: Route,
+    pub summarize: Route,
+    pub reasoning: Route,
+    pub high_risk: Route,
+    pub unknown: Route,
+}
+
+#[derive(Clone, Debug)]
+pub struct RouteInput {
+    pub task_class: TaskClass,
+    pub confidence: Option<f64>,
+    pub schema_valid: Option<bool>,
+    pub budget_soft_limit_reached: bool,
+    pub budget_hard_limit_reached: bool,
+    pub cloud_required: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RouteDecision {
+    pub task_class: TaskClass,
+    pub route: Route,
+    pub reason_codes: Vec<String>,
+    pub should_degrade_local: bool,
+    pub policy_version: String,
+}
+
+impl Default for EffectiveRouterPolicy {
+    fn default() -> Self {
+        Self {
+            policy_version: "router-v1".to_string(),
+            min_local_confidence: 0.78,
+            defaults: EffectiveRouterDefaults {
+                embed: Route::LocalOnly,
+                classify: Route::LocalThenCloud,
+                extract: Route::LocalThenCloud,
+                summarize: Route::LocalThenCloud,
+                reasoning: Route::CloudOnly,
+                high_risk: Route::CloudOnly,
+                unknown: Route::LocalThenCloud,
+            },
+        }
+    }
+}
+
+pub fn load_policy(path: Option<&Path>) -> Result<EffectiveRouterPolicy> {
+    let Some(path) = path else {
+        return Ok(EffectiveRouterPolicy::default());
+    };
+
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed reading router policy: {}", path.display()))?;
+    let parsed: RouterPolicy = toml::from_str(&content)
+        .with_context(|| format!("failed parsing router policy TOML: {}", path.display()))?;
+
+    let mut effective = EffectiveRouterPolicy::default();
+
+    if let Some(version) = parsed.policy_version {
+        effective.policy_version = version;
+    }
+
+    if let Some(t) = parsed.thresholds
+        && let Some(min_local_confidence) = t.min_local_confidence
+    {
+        effective.min_local_confidence = min_local_confidence;
+    }
+
+    if let Some(d) = parsed.defaults {
+        if let Some(v) = d.embed {
+            effective.defaults.embed = v;
+        }
+        if let Some(v) = d.classify {
+            effective.defaults.classify = v;
+        }
+        if let Some(v) = d.extract {
+            effective.defaults.extract = v;
+        }
+        if let Some(v) = d.summarize {
+            effective.defaults.summarize = v;
+        }
+        if let Some(v) = d.reasoning {
+            effective.defaults.reasoning = v;
+        }
+        if let Some(v) = d.high_risk {
+            effective.defaults.high_risk = v;
+        }
+        if let Some(v) = d.unknown {
+            effective.defaults.unknown = v;
+        }
+    }
+
+    Ok(effective)
+}
+
+fn default_route_for(task: &TaskClass, policy: &EffectiveRouterPolicy) -> Route {
+    match task {
+        TaskClass::Embed => policy.defaults.embed.clone(),
+        TaskClass::Classify => policy.defaults.classify.clone(),
+        TaskClass::Extract => policy.defaults.extract.clone(),
+        TaskClass::Summarize => policy.defaults.summarize.clone(),
+        TaskClass::Reasoning => policy.defaults.reasoning.clone(),
+        TaskClass::HighRisk => policy.defaults.high_risk.clone(),
+        TaskClass::Unknown => policy.defaults.unknown.clone(),
+    }
+}
+
+pub fn decide_route(input: &RouteInput, policy: &EffectiveRouterPolicy) -> RouteDecision {
+    let mut reason_codes = Vec::<String>::new();
+    let mut route = default_route_for(&input.task_class, policy);
+    let mut should_degrade_local = false;
+
+    if input.cloud_required {
+        route = Route::CloudOnly;
+        reason_codes.push("explicit_cloud_required".into());
+    }
+
+    if matches!(input.task_class, TaskClass::Embed) {
+        route = Route::LocalOnly;
+        reason_codes.push("embed_local_default".into());
+    }
+
+    if matches!(
+        input.task_class,
+        TaskClass::Classify | TaskClass::Extract | TaskClass::Summarize
+    ) {
+        if input.schema_valid == Some(false) {
+            route = Route::LocalThenCloud;
+            reason_codes.push("schema_validation_failed".into());
+        } else if let Some(confidence) = input.confidence {
+            if confidence >= policy.min_local_confidence {
+                route = Route::LocalOnly;
+                reason_codes.push("confidence_gate_passed".into());
+            } else {
+                route = Route::LocalThenCloud;
+                reason_codes.push("confidence_gate_low".into());
+            }
+        } else {
+            route = Route::LocalThenCloud;
+            reason_codes.push("confidence_missing".into());
+        }
+    }
+
+    if input.budget_soft_limit_reached && matches!(route, Route::CloudOnly) {
+        route = Route::LocalThenCloud;
+        reason_codes.push("budget_soft_limit_route_downshift".into());
+    }
+
+    if input.budget_hard_limit_reached && matches!(route, Route::CloudOnly | Route::LocalThenCloud)
+    {
+        route = Route::LocalOnly;
+        should_degrade_local = true;
+        reason_codes.push("budget_hard_limit_cloud_blocked".into());
+    }
+
+    if reason_codes.is_empty() {
+        reason_codes.push("default_policy_route".into());
+    }
+
+    RouteDecision {
+        task_class: input.task_class.clone(),
+        route,
+        reason_codes,
+        should_degrade_local,
+        policy_version: policy.policy_version.clone(),
+    }
+}
+
+pub fn decision_log_json(decision: &RouteDecision) -> Result<String> {
+    serde_json::to_string(decision).context("failed to serialize route decision")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn baseline_policy() -> EffectiveRouterPolicy {
+        EffectiveRouterPolicy::default()
+    }
+
+    #[test]
+    fn embed_always_routes_local_only() {
+        let input = RouteInput {
+            task_class: TaskClass::Embed,
+            confidence: Some(0.2),
+            schema_valid: Some(false),
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: true,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::LocalOnly);
+        assert!(
+            decision
+                .reason_codes
+                .contains(&"embed_local_default".to_string())
+        );
+    }
+
+    #[test]
+    fn reasoning_routes_cloud_only_without_budget_pressure() {
+        let input = RouteInput {
+            task_class: TaskClass::Reasoning,
+            confidence: None,
+            schema_valid: None,
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::CloudOnly);
+    }
+
+    #[test]
+    fn hard_budget_limit_blocks_cloud_and_degrades_local() {
+        let input = RouteInput {
+            task_class: TaskClass::Reasoning,
+            confidence: None,
+            schema_valid: None,
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: true,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::LocalOnly);
+        assert!(decision.should_degrade_local);
+        assert!(
+            decision
+                .reason_codes
+                .contains(&"budget_hard_limit_cloud_blocked".to_string())
+        );
+    }
+
+    #[test]
+    fn soft_budget_limit_downshifts_cloud_only() {
+        let input = RouteInput {
+            task_class: TaskClass::HighRisk,
+            confidence: None,
+            schema_valid: None,
+            budget_soft_limit_reached: true,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::LocalThenCloud);
+        assert!(
+            decision
+                .reason_codes
+                .contains(&"budget_soft_limit_route_downshift".to_string())
+        );
+    }
+
+    #[test]
+    fn classify_with_high_confidence_stays_local() {
+        let input = RouteInput {
+            task_class: TaskClass::Classify,
+            confidence: Some(0.95),
+            schema_valid: Some(true),
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::LocalOnly);
+        assert!(
+            decision
+                .reason_codes
+                .contains(&"confidence_gate_passed".to_string())
+        );
+    }
+
+    #[test]
+    fn classify_with_low_confidence_uses_local_then_cloud() {
+        let input = RouteInput {
+            task_class: TaskClass::Classify,
+            confidence: Some(0.35),
+            schema_valid: Some(true),
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::LocalThenCloud);
+        assert!(
+            decision
+                .reason_codes
+                .contains(&"confidence_gate_low".to_string())
+        );
+    }
+
+    #[test]
+    fn schema_failure_for_extract_forces_escalation_path() {
+        let input = RouteInput {
+            task_class: TaskClass::Extract,
+            confidence: Some(0.99),
+            schema_valid: Some(false),
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+
+        assert_eq!(decision.route, Route::LocalThenCloud);
+        assert!(
+            decision
+                .reason_codes
+                .contains(&"schema_validation_failed".to_string())
+        );
+    }
+
+    #[test]
+    fn decisions_are_deterministic_for_identical_inputs() {
+        let input = RouteInput {
+            task_class: TaskClass::Summarize,
+            confidence: Some(0.81),
+            schema_valid: Some(true),
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+        let policy = baseline_policy();
+
+        let first = decide_route(&input, &policy);
+        let second = decide_route(&input, &policy);
+
+        assert_eq!(first.route, second.route);
+        assert_eq!(first.reason_codes, second.reason_codes);
+        assert_eq!(first.should_degrade_local, second.should_degrade_local);
+    }
+
+    #[test]
+    fn route_decision_serializes_to_json_log() {
+        let input = RouteInput {
+            task_class: TaskClass::Unknown,
+            confidence: None,
+            schema_valid: None,
+            budget_soft_limit_reached: false,
+            budget_hard_limit_reached: false,
+            cloud_required: false,
+        };
+
+        let decision = decide_route(&input, &baseline_policy());
+        let log_line = decision_log_json(&decision).expect("serialize decision");
+
+        assert!(log_line.contains("\"route\""));
+        assert!(log_line.contains("\"policy_version\""));
+    }
+}


### PR DESCRIPTION
## Summary
Implements PR-1 of the local-first roadmap:
- deterministic router decision engine (`local_only | local_then_cloud | cloud_only`)
- policy schema + baseline policy (`policies/router.toml`)
- CLI dry-run router mode with structured decision log
- architecture + 14-day execution docs
- QA/validation report and updated launch messaging

## Why
Foundation for "cloud only when needed" execution model while keeping current condensing flow backward-compatible.

## Test plan
- `cargo test -q`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- router dry-run scenario checks (embed/reasoning/classify/high_risk)

## No metric, no merge
- Unit tests: 22 passed / 0 failed
- Behavioral validation: 5/5 expected route outcomes matched
- Lint/format: pass
- Backward compatibility: existing condense path unchanged unless router flags are used
