### PR TITLE
feat: PR2 local embeddings lane (local-only, cloud_calls=0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ gh attestation verify octk-x86_64-unknown-linux-gnu.tar.gz \
   --emit-route-log
 ```
 
+### Local embeddings lane (PR2)
+```bash
+# local-only embedding health
+./target/release/octk --embed-health-check --emit-embed-log
+
+# local embedding + local index append
+./target/release/octk \
+  --embed-input "OpenClaw local embedding test" \
+  --embed-dim 64 \
+  --embed-model octk-local-hash-v1 \
+  --embed-index-path ./rag/local-index.jsonl \
+  --emit-embed-log
+```
+
 ### Wrapper controls
 ```bash
 # default (balanced profile)
@@ -210,7 +224,9 @@ See: `docs/OPENCLAW_INTEGRATION.md`
 - `docs/PRODUCT_GUARDRAILS.md`
 - `docs/LOCAL_FIRST_ROUTING_ARCHITECTURE.md`
 - `docs/EXECUTION_PLAN_14D_LOCAL_FIRST.md`
+- `docs/LOCAL_EMBEDDINGS_LANE_PR2.md`
 - `docs/QA_VALIDATION_2026-03-23_LOCAL_FIRST_PR1.md`
+- `docs/QA_VALIDATION_2026-03-23_LOCAL_EMBEDDINGS_PR2.md`
 - `SECURITY.md`, `scripts/secret-check.sh`
 
 If you run this in production, open an issue with:

--- a/docs/LAUNCH_POST_DE.md
+++ b/docs/LAUNCH_POST_DE.md
@@ -13,6 +13,7 @@ Das erhöht Kosten, Latenz und drückt auf das Context Window.
 - Profile (`safe`, `balanced`, `aggressive`)
 - klare Marker + messbare Token-Einsparung
 - Local-First Router Dry-Run (policy-basierte Routenentscheidung)
+- Local Embeddings Lane (`route=local_only`, `cloud_calls=0`)
 - fail-open Design (kein OpenClaw-Core-Patching)
 
 ## Reale Zahlen

--- a/docs/LAUNCH_POST_EN.md
+++ b/docs/LAUNCH_POST_EN.md
@@ -13,6 +13,7 @@ That increases cost, latency, and context pressure.
 - profile presets (`safe`, `balanced`, `aggressive`)
 - explicit usage markers + measurable token savings
 - local-first router dry-run (policy-based route decisions)
+- local embeddings lane (`route=local_only`, `cloud_calls=0`)
 - fail-open design (no OpenClaw core patching)
 
 ## Real numbers

--- a/docs/LOCAL_EMBEDDINGS_LANE_PR2.md
+++ b/docs/LOCAL_EMBEDDINGS_LANE_PR2.md
@@ -1,0 +1,46 @@
+# PR2 — Local Embeddings Lane
+
+## Goal
+Run embedding requests locally by default and write vectors into a local index path without cloud API calls.
+
+## Delivered
+- Local embedding module: `src/embeddings.rs`
+- Deterministic hash-based local embedding generator
+- Health check mode for local embedding lane
+- JSONL index append path for local RAG ingestion
+- CLI integration in `octk`
+
+## CLI
+### Health check
+```bash
+octk --embed-health-check --emit-embed-log
+```
+
+### Inline input embedding
+```bash
+octk \
+  --embed-input "OpenClaw local embedding test" \
+  --embed-dim 64 \
+  --embed-model octk-local-hash-v1 \
+  --embed-index-path ./rag/local-index.jsonl \
+  --emit-embed-log
+```
+
+### File input embedding
+```bash
+octk \
+  --embed-input-file ./docs/sample.txt \
+  --embed-index-path ./rag/local-index.jsonl
+```
+
+## Output contract
+The embedding output is JSON with:
+- `route: "local_only"`
+- `cloud_calls: 0`
+- `reason_codes` containing `local_embedding_lane`
+- deterministic `id`, `dims`, and `vector`
+
+## Notes
+- This lane is intentionally local-only for embeddings.
+- Cloud fallback for embeddings is not used in PR2 by design.
+- PR3/PR4 will add broader local inference + escalation control paths for non-embedding tasks.

--- a/docs/MOAT_POSITIONING.md
+++ b/docs/MOAT_POSITIONING.md
@@ -12,6 +12,7 @@ Now extended to **local-first routing discipline** (cloud only when needed).
    - Designed for real OpenClaw workflows (profiles, wrapper, deploy-health, fail-open).
 2. **Deterministic behavior**
    - Rule-based condensing with predictable outcomes.
+   - Local embeddings lane with explicit `cloud_calls=0` contract.
 3. **Proof, not promises**
    - Explicit before/after metrics and usage markers (`RUST_TOOLKIT_DETECTED`, `RUST_TOOLKIT_USED`).
 4. **Upgrade-safe architecture**

--- a/docs/QA_VALIDATION_2026-03-23_LOCAL_EMBEDDINGS_PR2.md
+++ b/docs/QA_VALIDATION_2026-03-23_LOCAL_EMBEDDINGS_PR2.md
@@ -1,0 +1,44 @@
+# QA + Validation Report — PR2 Local Embeddings Lane (2026-03-23)
+
+## Scope
+- Local embedding generation in Rust (`src/embeddings.rs`)
+- CLI embedding modes (`--embed-*`)
+- Local JSONL index append path
+- Health check for local embedding lane
+
+## A) Testen
+Commands:
+```bash
+cargo test -q
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## B) Reparieren
+- Während Implementierung keine logischen Defekte offen.
+- Rustfmt-Layout auf finalen Stand gebracht.
+
+## C) Validieren
+### Behavior checks
+```bash
+cargo run --quiet -- --embed-health-check --emit-embed-log
+cargo run --quiet -- --embed-input "abc" --embed-dim 32 --embed-index-path /tmp/octk-emb-index.jsonl --emit-embed-log
+```
+
+Expected/observed:
+- Health reports `local_available=true`
+- Embedding output includes:
+  - `route: "local_only"`
+  - `cloud_calls: 0`
+  - reason includes `local_embedding_lane`
+- Index file append works (JSONL line written)
+
+## D) Dokumentieren
+- `docs/LOCAL_EMBEDDINGS_LANE_PR2.md`
+- `README.md` updated with local embedding examples
+
+## No metric, no merge block
+- Unit tests: pass
+- Compile/lint/style gates: pass
+- Embedding lane cloud calls in validation: **0**
+- Backward compatibility: condensing and router flows unchanged unless embed flags are used

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -1,0 +1,190 @@
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::collections::hash_map::DefaultHasher;
+use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::Write;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Serialize)]
+pub struct EmbeddingRecord {
+    pub id: String,
+    pub model: String,
+    pub dims: usize,
+    pub text_chars: usize,
+    pub vector: Vec<f32>,
+    pub route: String,
+    pub cloud_calls: u32,
+    pub reason_codes: Vec<String>,
+    pub created_at_unix: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbeddingHealth {
+    pub local_available: bool,
+    pub model: String,
+    pub cloud_calls: u32,
+    pub reason_codes: Vec<String>,
+}
+
+pub fn local_embedding_health(model: &str) -> EmbeddingHealth {
+    EmbeddingHealth {
+        local_available: true,
+        model: model.to_string(),
+        cloud_calls: 0,
+        reason_codes: vec!["local_embedding_lane_ready".to_string()],
+    }
+}
+
+pub fn build_local_embedding_record(
+    text: &str,
+    dim: usize,
+    id: Option<&str>,
+    model: &str,
+) -> Result<EmbeddingRecord> {
+    let clean_dim = dim.max(8);
+    let vector = embed_text_hash(text, clean_dim);
+    let generated_id = id
+        .map(ToString::to_string)
+        .unwrap_or_else(|| stable_text_id(text, clean_dim));
+
+    let created_at_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system time before unix epoch")?
+        .as_secs();
+
+    Ok(EmbeddingRecord {
+        id: generated_id,
+        model: model.to_string(),
+        dims: clean_dim,
+        text_chars: text.chars().count(),
+        vector,
+        route: "local_only".to_string(),
+        cloud_calls: 0,
+        reason_codes: vec!["local_embedding_lane".to_string()],
+        created_at_unix,
+    })
+}
+
+pub fn append_record_jsonl(path: &Path, record: &EmbeddingRecord) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create index directory: {}", parent.display()))?;
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open index file: {}", path.display()))?;
+
+    let line = serde_json::to_string(record).context("failed to serialize embedding record")?;
+    writeln!(file, "{}", line)
+        .with_context(|| format!("failed to append index file: {}", path.display()))?;
+
+    Ok(())
+}
+
+fn stable_text_id(text: &str, dim: usize) -> String {
+    let mut hasher = DefaultHasher::new();
+    text.hash(&mut hasher);
+    dim.hash(&mut hasher);
+    format!("emb-{:016x}", hasher.finish())
+}
+
+fn embed_text_hash(text: &str, dim: usize) -> Vec<f32> {
+    let mut bins = vec![0.0_f32; dim];
+    if text.trim().is_empty() {
+        return bins;
+    }
+
+    for token in text.split_whitespace() {
+        let lower = token.to_ascii_lowercase();
+        let idx = stable_index(&lower, dim);
+        bins[idx] += 1.0;
+
+        if lower.len() >= 4 {
+            let prefix = &lower[..4];
+            let idx2 = stable_index(prefix, dim);
+            bins[idx2] += 0.5;
+        }
+    }
+
+    l2_normalize(&mut bins);
+    bins
+}
+
+fn stable_index(token: &str, dim: usize) -> usize {
+    let mut hasher = DefaultHasher::new();
+    token.hash(&mut hasher);
+    (hasher.finish() as usize) % dim
+}
+
+fn l2_normalize(v: &mut [f32]) {
+    let norm_sq: f32 = v.iter().map(|x| x * x).sum();
+    if norm_sq <= f32::EPSILON {
+        return;
+    }
+    let norm = norm_sq.sqrt();
+    for x in v.iter_mut() {
+        *x /= norm;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedding_has_requested_dim() {
+        let rec = build_local_embedding_record("hello world", 64, None, "octk-local-hash-v1")
+            .expect("record");
+        assert_eq!(rec.vector.len(), 64);
+        assert_eq!(rec.dims, 64);
+    }
+
+    #[test]
+    fn embedding_is_deterministic_for_same_input() {
+        let r1 = build_local_embedding_record("same text", 32, None, "octk-local-hash-v1")
+            .expect("record1");
+        let r2 = build_local_embedding_record("same text", 32, None, "octk-local-hash-v1")
+            .expect("record2");
+
+        assert_eq!(r1.id, r2.id);
+        assert_eq!(r1.vector, r2.vector);
+    }
+
+    #[test]
+    fn embedding_route_is_local_and_cloud_calls_zero() {
+        let rec = build_local_embedding_record("abc", 16, Some("x"), "octk-local-hash-v1")
+            .expect("record");
+        assert_eq!(rec.route, "local_only");
+        assert_eq!(rec.cloud_calls, 0);
+        assert!(
+            rec.reason_codes
+                .contains(&"local_embedding_lane".to_string())
+        );
+    }
+
+    #[test]
+    fn health_check_reports_local_ready() {
+        let health = local_embedding_health("octk-local-hash-v1");
+        assert!(health.local_available);
+        assert_eq!(health.cloud_calls, 0);
+    }
+
+    #[test]
+    fn append_record_writes_jsonl() {
+        let temp_dir = std::env::temp_dir().join("octk-embeddings-test");
+        let path = temp_dir.join("index.jsonl");
+        let _ = fs::remove_file(&path);
+
+        let rec = build_local_embedding_record("hello", 16, Some("id-1"), "octk-local-hash-v1")
+            .expect("record");
+        append_record_jsonl(&path, &rec).expect("append");
+
+        let content = fs::read_to_string(&path).expect("read back");
+        assert!(content.contains("\"id\":\"id-1\""));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
+mod embeddings;
 mod router;
 
 #[derive(Parser, Debug)]
@@ -54,6 +55,30 @@ struct Cli {
 
     #[arg(long, default_value_t = false)]
     emit_route_log: bool,
+
+    #[arg(long)]
+    embed_input: Option<String>,
+
+    #[arg(long)]
+    embed_input_file: Option<PathBuf>,
+
+    #[arg(long, default_value_t = 64)]
+    embed_dim: usize,
+
+    #[arg(long)]
+    embed_id: Option<String>,
+
+    #[arg(long, default_value = "octk-local-hash-v1")]
+    embed_model: String,
+
+    #[arg(long)]
+    embed_index_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = false)]
+    embed_health_check: bool,
+
+    #[arg(long, default_value_t = false)]
+    emit_embed_log: bool,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -435,8 +460,54 @@ fn process_input(
     (output, used, final_reason)
 }
 
+fn resolve_embed_input(cli: &Cli) -> Result<Option<String>> {
+    if let Some(inline) = &cli.embed_input {
+        return Ok(Some(inline.clone()));
+    }
+
+    if let Some(path) = &cli.embed_input_file {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed reading embed input file: {}", path.display()))?;
+        return Ok(Some(content));
+    }
+
+    Ok(None)
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if cli.embed_health_check {
+        let health = embeddings::local_embedding_health(&cli.embed_model);
+        println!("{}", serde_json::to_string_pretty(&health)?);
+
+        if cli.emit_embed_log {
+            eprintln!("[EMBED_LOCAL_HEALTH] {}", serde_json::to_string(&health)?);
+        }
+
+        return Ok(());
+    }
+
+    if let Some(embed_text) = resolve_embed_input(&cli)? {
+        let record = embeddings::build_local_embedding_record(
+            &embed_text,
+            cli.embed_dim,
+            cli.embed_id.as_deref(),
+            &cli.embed_model,
+        )?;
+
+        if let Some(path) = &cli.embed_index_path {
+            embeddings::append_record_jsonl(path, &record)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&record)?);
+
+        if cli.emit_embed_log {
+            eprintln!("[EMBED_LOCAL] {}", serde_json::to_string(&record)?);
+        }
+
+        return Ok(());
+    }
 
     if let Some(task_class) = cli.route_task.clone() {
         let policy = router::load_policy(cli.route_policy.as_deref())?;
@@ -682,6 +753,73 @@ mod tests {
         assert_eq!(output, input);
         assert!(!used);
         assert_eq!(reason, "below_threshold");
+    }
+
+    #[test]
+    fn resolve_embed_input_prefers_inline_value() {
+        let cli = Cli {
+            mode: Mode::Auto,
+            command: None,
+            rules: None,
+            report_format: ReportFormat::Text,
+            report_file: None,
+            emit_flag: false,
+            route_task: None,
+            route_policy: None,
+            route_confidence: None,
+            route_schema_valid: None,
+            route_budget_soft_limit: false,
+            route_budget_hard_limit: false,
+            route_cloud_required: false,
+            emit_route_log: false,
+            embed_input: Some("hello".to_string()),
+            embed_input_file: None,
+            embed_dim: 64,
+            embed_id: None,
+            embed_model: "octk-local-hash-v1".to_string(),
+            embed_index_path: None,
+            embed_health_check: false,
+            emit_embed_log: false,
+        };
+
+        let resolved = resolve_embed_input(&cli).expect("resolve inline");
+        assert_eq!(resolved.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn resolve_embed_input_reads_from_file() {
+        let path = std::env::temp_dir().join("octk-embed-input-test.txt");
+        fs::write(&path, "file-text").expect("write temp file");
+
+        let cli = Cli {
+            mode: Mode::Auto,
+            command: None,
+            rules: None,
+            report_format: ReportFormat::Text,
+            report_file: None,
+            emit_flag: false,
+            route_task: None,
+            route_policy: None,
+            route_confidence: None,
+            route_schema_valid: None,
+            route_budget_soft_limit: false,
+            route_budget_hard_limit: false,
+            route_cloud_required: false,
+            emit_route_log: false,
+            embed_input: None,
+            embed_input_file: Some(path.clone()),
+            embed_dim: 64,
+            embed_id: None,
+            embed_model: "octk-local-hash-v1".to_string(),
+            embed_index_path: None,
+            embed_health_check: false,
+            emit_embed_log: false,
+        };
+
+        let resolved = resolve_embed_input(&cli).expect("resolve file");
+        assert_eq!(resolved.as_deref(), Some("file-text"));
+
+        let _ = fs::remove_file(path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Implements PR2 from the local-first plan:
- Adds a local embeddings lane (`src/embeddings.rs`)
- Adds CLI embedding modes (`--embed-*`) to generate local vectors and append JSONL index records
- Adds embedding lane health check (`--embed-health-check`)
- Adds docs + QA validation report + product marketing updates

## Why
Reduce API costs robustly by keeping embedding workloads local by default.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test -q`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Embedding behavior checks:
  - `--embed-health-check`
  - `--embed-input ... --embed-index-path ...`

## No metric, no merge
- Tests: **29/29 pass**
- Lint/style gates: **pass**
- Validation embedding output:
  - `route=local_only`
  - `cloud_calls=0`
- Local index append path validated (`index lines: 1`)
- Backward compatibility: condense/router flows unchanged unless `--embed-*` flags are used
